### PR TITLE
CMake: Search for ssh2 instead of libssh2.

### DIFF
--- a/cmake/SelectSSH.cmake
+++ b/cmake/SelectSSH.cmake
@@ -1,6 +1,6 @@
 # Optional external dependency: libssh2
 if(USE_SSH)
-	find_pkglibraries(LIBSSH2 libssh2)
+	find_pkglibraries(LIBSSH2 ssh2)
 	if(NOT LIBSSH2_FOUND)
 		find_package(LibSSH2)
 		set(LIBSSH2_INCLUDE_DIRS ${LIBSSH2_INCLUDE_DIR})


### PR DESCRIPTION
Fixes "CMake Error: could not resolve ssh2" on Windows-MSVC.